### PR TITLE
remove-appcelerator-reference

### DIFF
--- a/hash_client_api.adoc
+++ b/hash_client_api.adoc
@@ -16,7 +16,6 @@ Generate hash value of a string.
 * JavaScript SDK
 ** Cordova
 ** Web Apps
-** Appcelerator
 
 For detailed version information, see link:https://access.redhat.com/node/2357761[Supported Configurations^].
 


### PR DESCRIPTION
We are removing the appcelerator app from the studio. Removing all references in the repos also